### PR TITLE
sum over rows instead of columns

### DIFF
--- a/src/aind_smartspim_transform_utils/CoordinateTransform.py
+++ b/src/aind_smartspim_transform_utils/CoordinateTransform.py
@@ -514,7 +514,7 @@ class CoordinateTransform:
 
         reg_dims = [dim / 2**reg_ds for dim in input_shape]
 
-        for idx, dim_orient in enumerate(mat.sum(axis=1)):
+        for idx, dim_orient in enumerate(mat.sum(axis=0)):
             if dim_orient < 0:
                 scaled_pts[:, idx] = reg_dims[idx] - scaled_pts[:, idx]
 


### PR DESCRIPTION
This fixes a bug in `CoordinateTransform.reverse_transform`. `get_orientation_transform` constructs a matrix where the rows are the input order and the columns are the output order. When we mirror the axes we need to sum over the rows instead of columns since the orientation order has already been swapped to the original image order [here](https://github.com/AllenNeuralDynamics/aind-smartspim-transform-utils/blob/main/src/aind_smartspim_transform_utils/CoordinateTransform.py#L493)

I tested this change and it mirrored the right axes after the change whereas before it was mirroring the wrong axes.