### PR TITLE
removed print statement from file_io.get_transforms

### DIFF
--- a/src/aind_smartspim_transform_utils/io/file_io.py
+++ b/src/aind_smartspim_transform_utils/io/file_io.py
@@ -212,8 +212,6 @@ def get_transforms(dataset_path: str, channel: str, dest=None) -> list:
             dataset_path, "image_atlas_alignment", channel
         )
 
-        print(f"Pulling dataset transforms from {transforms_path}")
-
     try:
         transforms["points_to_ccf"] = [
             glob(os.path.join(transforms_path, "*SyN_0GenericAffine.mat"))[0],


### PR DESCRIPTION
removing print statement to avoid overflowing the page when iterating over many samples. alternatively i can add verbosity control.